### PR TITLE
Update geeksoftwareGmbH.PDF24Creator.installer.yaml

### DIFF
--- a/manifests/g/geeksoftwareGmbH/PDF24Creator/11.16.0/geeksoftwareGmbH.PDF24Creator.installer.yaml
+++ b/manifests/g/geeksoftwareGmbH/PDF24Creator/11.16.0/geeksoftwareGmbH.PDF24Creator.installer.yaml
@@ -9,12 +9,12 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerType: wix
-  InstallerUrl: https://download0.pdf24.org/pdf24-creator-11.16.0-x64.msi
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.16.0-x64.msi
   InstallerSha256: 943298FC962DBF3DA56F21C93D9AE078131B6BF37467163EFA8F5EAB3FF69CCB
   ProductCode: '{C07ED6F8-0D7C-4408-AA24-61DB6633F201}'
 - Architecture: x64
   InstallerType: inno
-  InstallerUrl: https://download1.pdf24.org/pdf24-creator-11.16.0-x64.exe
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.16.0-x64.exe
   InstallerSha256: 8B6633776BE77D7278E4C5D8C9AAD13B98CA653CFB8A0C4C6639E4F634B3992B
   InstallerSwitches:
     Custom: /NOUPDATE /NORESTART
@@ -23,12 +23,12 @@ Installers:
     ProductCode: '{81A6F461-0DBA-4F12-B56F-0E977EC10576}_is1'
 - Architecture: x86
   InstallerType: wix
-  InstallerUrl: https://download1.pdf24.org/pdf24-creator-11.16.0-x86.msi
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.16.0-x86.msi
   InstallerSha256: FB14BE6110B08E04D5AB9418AD3987BA8F47BE62983FD645D15AAA463F604849
   ProductCode: '{ED97E6C5-2368-4AFD-92D2-3D93AD2CCE3B}'
 - Architecture: x86
   InstallerType: inno
-  InstallerUrl: https://download2.pdf24.org/pdf24-creator-11.16.0-x86.exe
+  InstallerUrl: https://download.pdf24.org/pdf24-creator-11.16.0-x86.exe
   InstallerSha256: D10F1A398652C43AE40E57FEE3A3C27E9B2B605BB37C44F0FDCB12D234619887
   InstallerSwitches:
     Custom: /NOUPDATE /NORESTART


### PR DESCRIPTION
Fixed download URLs. Please always use download.pdf24.org.
